### PR TITLE
fix: listener not close

### DIFF
--- a/forwarder.go
+++ b/forwarder.go
@@ -159,6 +159,7 @@ func (tun *ForwardConfig) Start(ctx context.Context) error {
 	if err != nil {
 		return tun.stop(fmt.Errorf("remote listen %s on %s failed: %w", tun.Remote.Type(), tun.Remote.String(), err))
 	}
+	defer listener.Close()
 
 	errChan := make(chan error)
 	go func() {

--- a/forwarder.go
+++ b/forwarder.go
@@ -155,7 +155,6 @@ func (tun *ForwardConfig) Start(ctx context.Context) error {
 	}
 
 	listener, err = sshClient.Listen(tun.Remote.Type(), tun.Remote.String())
-	defer listener.Close()
 	if err != nil {
 		return tun.stop(fmt.Errorf("remote listen %s on %s failed: %w", tun.Remote.Type(), tun.Remote.String(), err))
 	}

--- a/forwarder.go
+++ b/forwarder.go
@@ -155,6 +155,7 @@ func (tun *ForwardConfig) Start(ctx context.Context) error {
 	}
 
 	listener, err = sshClient.Listen(tun.Remote.Type(), tun.Remote.String())
+	defer listener.Close()
 	if err != nil {
 		return tun.stop(fmt.Errorf("remote listen %s on %s failed: %w", tun.Remote.Type(), tun.Remote.String(), err))
 	}
@@ -184,9 +185,9 @@ func (tun *ForwardConfig) listen(listener net.Listener) error {
 		}
 
 		if conn, err := listener.Accept(); err == nil {
-			go func() {
+			go func(conn net.Conn) {
 				_ = tun.handle(conn)
-			}()
+			}(conn)
 		}
 	}
 }


### PR DESCRIPTION
commit [cf3481](https://github.com/oomol-lab/ssh-forward/commit/cf3481e003f9aa750f0ec4419424bc0b33ea6e44) delete `listener.Close()` by mistake.